### PR TITLE
IPv6 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,24 @@
 var addrToIPPort = require('addr-to-ip-port')
+var ipaddr = require('ipaddr.js')
 
 module.exports = function (addrs) {
   if (typeof addrs === 'string') {
     addrs = [ addrs ]
   }
-  var buf = new Buffer(addrs.length * 6)
-  addrs.forEach(function (addr, i) {
-    var offset = i * 6
+
+  return Buffer.concat(addrs.map(function (addr) {
     var s = addrToIPPort(addr)
     if (s.length !== 2) {
       throw new Error('invalid address format, expecting: 10.10.10.5:128')
     }
 
-    var ip = s[0]
+    var ip = ipaddr.parse(s[0])
+    var ipBuf = new Buffer(ip.toByteArray())
     var port = Number(s[1])
-    var bytes = ip.split('.')
-
-    buf[offset] = Number(bytes[0])
-    buf[offset + 1] = Number(bytes[1])
-    buf[offset + 2] = Number(bytes[2])
-    buf[offset + 3] = Number(bytes[3])
-    buf.writeUInt16BE(port, offset + 4)
-
-  })
-
-  return buf
+    var portBuf = new Buffer(2)
+    portBuf.writeUInt16BE(port, 0)
+    return Buffer.concat([ipBuf, portBuf])
+  }))
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/feross/string2compact/issues"
   },
   "dependencies": {
-    "addr-to-ip-port": "^1.0.1"
+    "addr-to-ip-port": "^1.0.1",
+    "ipaddr.js": "^0.1.5"
   },
   "devDependencies": {
     "compact2string": "^1.2.0",

--- a/test/basic.js
+++ b/test/basic.js
@@ -9,6 +9,12 @@ test('single', function (t) {
   t.end()
 })
 
+test('single IPv6', function (t) {
+  var compact = string2compact('[2a03:2880:2110:9f07:face:b00c::1]:80')
+  t.deepEqual(compact, new Buffer('2a03288021109f07faceb00c000000010050', 'hex'))
+  t.end()
+})
+
 test('multi', function (t) {
   // For this test, we assume that the compact2string implementation is good and just run
   // the conversion in reverse and see if we get the same thing back
@@ -17,7 +23,15 @@ test('multi', function (t) {
   t.end()
 })
 
-test('mutli (byte check)', function (t) {
+test('multi IPv6', function (t) {
+  // For this test, we assume that the compact2string implementation is good and just run
+  // the conversion in reverse and see if we get the same thing back
+  var ips = [ '[2a03:2880:2110:9f07:face:b00c::1]:80', '[2a00:1450:4008:801::1011]:443' ]
+  t.deepEqual(compact2string.multi6(string2compact(ips)), ips)
+  t.end()
+})
+
+test('multi (byte check)', function (t) {
   var compacts = string2compact([ '10.10.10.5:128', '100.56.58.99:28525' ])
   t.deepEqual(compacts, new Buffer('0A0A0A05008064383a636f6d', 'hex'))
   t.end()


### PR DESCRIPTION
Support for IPv6 addresses in square brackets as asked for in https://github.com/bencevans/node-compact2string/pull/9

Note that it depends on https://github.com/feross/addr-to-ip-port/pull/2 and we'll need a dependency bump once this has been pushed to npm.
